### PR TITLE
refs #15 fix bug

### DIFF
--- a/jobdsl/pipelineJob/pipeline_20_search_youtube_video.groovy
+++ b/jobdsl/pipelineJob/pipeline_20_search_youtube_video.groovy
@@ -16,7 +16,7 @@ pipelineJob(jobName) {
     }
 	parameters {
 		stringParam("question", "", "youtubeの検索条件を指定する")
-		stringParam("maxResults", 5, "検索結果の取得数 1~50")
+		stringParam("maxResults", "5", "検索結果の取得数 1-50")
 		choiceParam("videoDuration", ["any", "long", "medium", "short"], "videoDuration パラメータは、動画の検索結果を期間に基づいてフィルタリングします。")
 		stringParam("publishedAfter", "2018-08-25T00:00:00Z", "いつ以降のものを取得するか")
 	}


### PR DESCRIPTION
ERROR: (pipeline_20_search_youtube_video.groovy, line 19) No signature of method: javaposse.jobdsl.dsl.helpers.BuildParametersContext.stringParam() is applicable for argument types: (java.lang.String, java.lang.Integer, java.lang.String) values: [maxResults, 5, 検索結果の取得数 1~50]
Possible solutions: stringParam(java.lang.String, java.lang.String), stringParam(java.lang.String, java.lang.String, java.lang.String), stringParam(java.lang.String), runParam(java.lang.String, java.lang.String), runParam(java.lang.String, java.lang.String, java.lang.String)